### PR TITLE
Drop some long unused variables

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -17,9 +17,6 @@
 #include "Kaleidoscope-LEDEffect-Rainbow.h"
 #include "Kaleidoscope-Model01-TestMode.h"
 
-uint8_t primary_keymap = 0;
-uint8_t temporary_keymap = 0;
-
 #define MACRO_ANY 2
 #define Key_Any M(MACRO_ANY)
 #define NUMPAD_KEYMAP 2


### PR DESCRIPTION
The `primary_keymap` and `temporary_keymap` variables have been long unused - drop them, so it does not confuse anyone reading the code.
