### PR TITLE
Add AlphaSquareEffect to the list of LED effects

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -15,6 +15,7 @@
 #include "Kaleidoscope-LEDEffect-Breathe.h"
 #include "Kaleidoscope-LEDEffect-Chase.h"
 #include "Kaleidoscope-LEDEffect-Rainbow.h"
+#include "Kaleidoscope-LED-AlphaSquare.h"
 #include "Kaleidoscope-LED-Stalker.h"
 #include "Kaleidoscope-Model01-TestMode.h"
 
@@ -134,7 +135,7 @@ void setup() {
 
     Kaleidoscope.use(&TestMode,
                      &LEDControl, &LEDOff,
-                     &StalkerEffect,
+                     &StalkerEffect, &AlphaSquareEffect,
                      &solidRed, &solidOrange, &solidYellow, &solidGreen, &solidBlue, &solidIndigo, &solidViolet,
                      &LEDBreatheEffect, &LEDRainbowEffect, &LEDRainbowWaveEffect, &LEDChaseEffect, &NumLock,
 


### PR DESCRIPTION
Now that the plugin is fixed, add the effect after Stalker (early so it can catch key events, without something else jumping on it first).
