### PR TITLE
Any: Support repeating

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -101,9 +101,14 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
   } else if (macroIndex == 1 && key_toggled_on(keyState)) {
     Macros.type(PSTR("Keyboardio Model 01 - Kaleidoscope "));
     Macros.type(PSTR(BUILD_INFORMATION));
-  } else if (macroIndex == MACRO_ANY && key_toggled_on(keyState)) {
-    Keyboard.press(Key_A.keyCode + (uint8_t)(millis() % 36));
-    Keyboard.sendReport();
+  } else if (macroIndex == MACRO_ANY) {
+    static uint8_t lastCode;
+
+    if (key_toggled_on(keyState))
+      lastCode = Key_A.keyCode + (uint8_t)(millis() % 36);
+
+    if (key_is_pressed(keyState))
+      Keyboard.press(lastCode);
   }
   return MACRO_NONE;
 }


### PR DESCRIPTION
Instead of reacting to the `Any` key only when it toggles on, figure out the code on toggling on, and keep that code held while the key is pressed. This allows the key to repeat while held.