### PR TITLE
Turn the Fn keys into Keymap1_Momentary

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -71,14 +71,14 @@ ___ \
     Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,                    \
     Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,        \
     Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,         \
-                          Key_KeymapNext_Momentary,     \
+                          Key_Keymap1_Momentary,     \
 \
     Macro_Any,       Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_ToggleNumlock, \
     Key_Enter,     Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,       \
                    Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,       \
     Key_RightAlt,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,       \
     Key_RightShift, Key_LeftAlt, Key_Spacebar, Key_RightControl,                   \
-    Key_KeymapNext_Momentary \
+    Key_Keymap1_Momentary \
 )
 
 const Key keymaps[][ROWS][COLS] PROGMEM = {


### PR DESCRIPTION
When both `Fn` keys are `KeymapNext_Momentary`, holding both would get us to the `NUMPAD` layer, which overrides the palm keys and turns them into `Keymap1_Momentary` keys. Thus, when releasing them, we would receive a release event for `Keymap1_Momentary`, not for `KeymapNext_Momentary`, and we'd be stuck on the `Numpad` layer until toggling it off.

To avoid this scenario, change the `KeymapNext_Momentary` keys into `Keymap1_Momentary`, so we never reach the `NUMPAD` layer via the `Fn` keys.

Fixes keyboardio/Kaleidoscope#151, with thanks to @chughes87 for the report!
