### PR TITLE
support arduino installed in non-default location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
-# This stub makefile for a Kaleidoscope plugin pulls in 
+# This stub makefile for a Kaleidoscope plugin pulls in
 # all targets from the Kaleidoscope-Plugin library
 
 MAKEFILE_PREFIX=keyboardio/avr/libraries/Kaleidoscope-Plugin/build
 UNAME_S := $(shell uname -s)
 
+ifneq ($(SKETCHBOOK_DIR),)
+BOARD_HARDWARE_PATH ?= $(SKETCHBOOK_DIR)/hardware
+else
 ifeq ($(UNAME_S),Darwin)
 BOARD_HARDWARE_PATH ?= $(HOME)/Documents/Arduino/hardware
 else
 BOARD_HARDWARE_PATH ?= $(HOME)/Arduino/hardware
+endif
 endif
 
 include $(BOARD_HARDWARE_PATH)/$(MAKEFILE_PREFIX)/rules.mk

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ SKETCHBOOK_DIR=$HOME/Documents/Arduino
 # on Linux the default is
 SKETCHBOOK_DIR=$HOME/Arduino
 
+# set needed environment variables
+ARDUINO_PATH=$SKETCHBOOK_DIR/arduino-1.8.3   # or whatever version you have
+ARDUINO_LOCAL_LIB_PATH=$SKETCHBOOK_DIR
+
 # make a directory for kaleidoscope, the Model 01 firmware
 mkdir $HOME/kaleidoscope
 


### PR DESCRIPTION
Change Makefile to pay attention to SKETCHBOOK_DIR enviroment variable
instead of assuming arduino is installed in the default location.
Update README to add environment variables which must be set if you
use a non-default location.