### PR TITLE
Updated to use the new NumLock plugin

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -74,7 +74,7 @@ ___ \
     Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,         \
                           Key_Keymap1_Momentary,     \
 \
-    Macro_Any,       Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_ToggleNumlock, \
+    Macro_Any,       Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_KeypadNumLock, \
     Key_Enter,     Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,       \
                    Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,       \
     Key_RightAlt,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,       \
@@ -97,9 +97,7 @@ static kaleidoscope::LEDSolidColor solidIndigo(0, 0, 170);
 static kaleidoscope::LEDSolidColor solidViolet(130, 0, 120);
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
-  if (macroIndex == TOGGLENUMLOCK && keyToggledOn(keyState)) {
-    return NumLock.toggle();
-  } else if (macroIndex == 1 && keyToggledOn(keyState)) {
+  if (macroIndex == 1 && keyToggledOn(keyState)) {
     Macros.type(PSTR("Keyboardio Model 01 - Kaleidoscope "));
     Macros.type(PSTR(BUILD_INFORMATION));
   } else if (macroIndex == MACRO_ANY) {


### PR DESCRIPTION
The NumLock plugin works without a macro now, so we can simplify the factory firmware by just using `Key_KeypadNumLock`.

Depends on keyboardio/Kaleidoscope-Numlock#9.