### PR TITLE
Remove the NULL from the end of Kaleidoscope.use

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -292,8 +292,8 @@ void setup() {
     &Macros,
 
     // The MouseKeys plugin lets you add keys to your keymap which move the mouse.
-    &MouseKeys,
-    NULL);
+    &MouseKeys
+  );
 
   // While we hope to improve this in the future, the NumLock plugin
   // needs to be explicitly told which keymap layer is your numpad layer


### PR DESCRIPTION
For a while now, `Kaleidoscope.use` does not require a NULL sentinel at the end. This drops the sentinel instead of adding documentation that would explain why that NULL is there.

On the other hand, there is a use for a sentinel: makes it clear that it is the end, and that one should add new plugins before it. With the NULL removed, I have to remember to put a comma after `&MouseKeys`, and not put one after any plugins I add. This exposes a bit of C syntax.

Nevertheless, I figured I'll let you decide which trade off you prefer. If you want to keep `NULL`, let me know, and I'll change this pull request into one that documents its intent.