### PR TITLE
Added a "LayerCount" variable to expose the number of defined layers

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -176,6 +176,12 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 /* Re-enable astyle's indent enforcement */
 // *INDENT-ON*
 
+// Calculate the number of layers defined in the "keymaps[]" array
+// above for use elsewhere in Kaleidoscope. Don't remove or modify
+// this line; it's used to prevent reading past the end of the array!
+const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);
+
+
 /** versionInfoMacro handles the 'firmware version info' macro
  *  When a key bound to the macro is pressed, this macro
  *  prints out the firmware build information as virtual keystrokes

--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -176,12 +176,6 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 /* Re-enable astyle's indent enforcement */
 // *INDENT-ON*
 
-// Calculate the number of layers defined in the "keymaps[]" array
-// above for use elsewhere in Kaleidoscope. Don't remove or modify
-// this line; it's used to prevent reading past the end of the array!
-const uint8_t LayerCount PROGMEM = sizeof(keymaps) / sizeof(*keymaps);
-
-
 /** versionInfoMacro handles the 'firmware version info' macro
  *  When a key bound to the macro is pressed, this macro
  *  prints out the firmware build information as virtual keystrokes
@@ -349,3 +343,6 @@ void setup() {
 void loop() {
   Kaleidoscope.loop();
 }
+
+// This line should always be at the end of the sketch file
+#include <sketch-trailer.h>


### PR DESCRIPTION
In order to prevent `Layer.next()` from reading past the end of the `keymaps[]` array into uninitialized memory, we need to know how many layers have been defined in the sketch. This is the only way I can think of to accomplish that.

This is the first step toward fixing [Kaleidoscope issue #243](https://github.com/keyboardio/Kaleidoscope/issues/243). There may be better ways to do it, but I can't think of any.