### PR TITLE
Updated definition of keymaps[] to use KEYMAPS() macro

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -125,7 +125,7 @@ enum { QWERTY, NUMPAD, FUNCTION }; // layers
  */
 // *INDENT-OFF*
 
-const Key keymaps[][ROWS][COLS] PROGMEM = {
+KEYMAPS(
 
   [QWERTY] = KEYMAP_STACKED
   (___,          Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
@@ -173,7 +173,7 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
    ___, ___, Key_Enter, ___,
    ___)
 
-};
+	) // KEYMAPS(
 
 /* Re-enable astyle's indent enforcement */
 // *INDENT-ON*


### PR DESCRIPTION
This change will enable the `layer_count` variable for preventing reading past the end of the `keymaps[]` array.

Now that the `KEYMAPS()` macro is in Kaleidoscope, we might as well update the default sketch here.