### PR TITLE
Match wildcard usage between manual- and arduino-installed environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PACKAGE_DIR ?= $(HOME)/.arduino15
 endif
 
 
-ARDUINO_INSTALLED_ENV=$(shell ls -dt $(PACKAGE_DIR)/packages/keyboardio/hardware/avr/* 2>/dev/null |head -n 1)
+ARDUINO_INSTALLED_ENV=$(shell ls -dt $(PACKAGE_DIR)/packages/keyboardio/hardware/avr 2>/dev/null |head -n 1)
 MANUALLY_INSTALLED_ENV=$(shell ls -dt $(SKETCHBOOK_DIR)/hardware/keyboardio/avr 2>/dev/null |head -n 1)
 
 


### PR DESCRIPTION
Finding the base-dir of installed environments use a wildcard causing
[dir]/packages/keyboardio/hardware/avr/toolchain to be the interpreted
as the installed env, breaking use of that variable later when it
informs paths for the boards.txt and other files.