### PR TITLE
Use CRGB to set the AlphaSquare color

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -349,7 +349,7 @@ void setup() {
   NumPad.numPadLayer = NUMPAD;
 
   // We configure the AlphaSquare effect to use RED letters
-  AlphaSquare.color = { 255, 0, 0 };
+  AlphaSquare.color = CRGB(255, 0, 0);
 
   // We set the brightness of the rainbow effects to 150 (on a scale of 0-255)
   // This draws more than 500mA, but looks much nicer than a dimmer effect


### PR DESCRIPTION
This makes the color match the description, and also shows the end-user how to use the `CRGB` macro to set colors.

Thanks to @danbernier for noticing the error!
