### PR TITLE
Use CRGB type for AlphaSquare color, so ints are in common order

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -349,7 +349,7 @@ void setup() {
   NumPad.numPadLayer = NUMPAD;
 
   // We configure the AlphaSquare effect to use RED letters
-  AlphaSquare.color = { 255, 0, 0 };
+  AlphaSquare.color = CRGB(255, 0, 0);
 
   // We set the brightness of the rainbow effects to 150 (on a scale of 0-255)
   // This draws more than 500mA, but looks much nicer than a dimmer effect


### PR DESCRIPTION
I noticed this surprise while I was reading through the firmware and playing around.

To state what's probably obvious to more experienced keyboardio hackers, this change has the effect of making the code comment match the code. When passing a...is that an array in C++?...when passing `{ int, int, int }`, the effect is that the numbers are interpreted as blue, green, red. The comment seems to expect the numbers in the more-common order, which seems to be the intent of the `CRGB` type. (Apologies, I'm probably using all the wrong words, I'm not a C++ programmer.)

Many thanks to @gedankenexperimenter and @jamesnvc for [their help in the forum](https://community.keyboard.io/t/minor-bug-in-arduino-example-rgb-order-for-alphasquare/1210/4)!