### PR TITLE
Make the Quote transparent on the NUMPAD layer.

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -156,7 +156,7 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
    M(MACRO_VERSION_INFO),  ___, Key_Keypad7, Key_Keypad8,   Key_Keypad9,        Key_KeypadSubtract, ___,
    ___,                    ___, Key_Keypad4, Key_Keypad5,   Key_Keypad6,        Key_KeypadAdd,      ___,
-                           ___, Key_Keypad1, Key_Keypad2,   Key_Keypad3,        Key_Equals,         Key_Quote,
+                           ___, Key_Keypad1, Key_Keypad2,   Key_Keypad3,        Key_Equals,         ___,
    ___,                    ___, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadDivide,   Key_Enter,
    ___, ___, ___, ___,
    ___),


### PR DESCRIPTION
Because the key two rows below `NumLock` is `Key_Quote` on the base layer too, and is not a numpad-specific key either, make it transparent, so it does not get highlighted erroneously.

Thanks to @ImmaculatePotato and Eddie Jinks for reporting the issue, and proposing the fix.

Fixes #48.
