### PR TITLE
Two small warning fixes

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -35,9 +35,6 @@
 // Support for "Numpad" mode, which is mostly just the Numpad specific LED mode
 #include "Kaleidoscope-NumPad.h"
 
-// Support for an "LED off mode"
-#include "LED-Off.h"
-
 // Support for the "Boot greeting" effect, which pulses the 'LED' button for 10s
 // when the keyboard is connected to a computer (or that computer is powered on)
 #include "Kaleidoscope-LEDEffect-BootGreeting.h"

--- a/src/Model01-Firmware.h
+++ b/src/Model01-Firmware.h
@@ -1,0 +1,2 @@
+// Lets make cpplint happy!
+#pragma once


### PR DESCRIPTION
This removes the `LED-Off.h` include, which is obsolete now, and adds a `#pragma once` to `src/Model01-Firmware.h`, to make cpplint happy.