### PR TITLE
Fix anyKeyMacro for new hid API

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -291,11 +291,14 @@ static void versionInfoMacro(uint8_t keyState) {
 
 static void anyKeyMacro(uint8_t keyState) {
   static Key lastKey;
-  if (keyToggledOn(keyState))
+  bool toggledOn = false;
+  if (keyToggledOn(keyState)) {
     lastKey.keyCode = Key_A.keyCode + (uint8_t)(millis() % 36);
+    toggledOn = true;
+  }
 
   if (keyIsPressed(keyState))
-    kaleidoscope::hid::pressKey(lastKey);
+    kaleidoscope::hid::pressKey(lastKey, toggledOn);
 }
 
 


### PR DESCRIPTION
The new HID api seems to have added a toggledOn field, so here is a version of the anyKeyMacro that works with that api.

Without this fix, the any key repeats on every loop, which is way too fast.