### PR TITLE
Explicitly initialize Serial

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -487,7 +487,10 @@ KALEIDOSCOPE_INIT_PLUGINS(
  * Kaleidoscope and any plugins.
  */
 void setup() {
-  // First, call Kaleidoscope's internal setup function
+  // First, initialize the virtual serial port
+  Serial.begin(9600);
+
+  // Then call Kaleidoscope's internal setup function
   Kaleidoscope.setup();
 
   // While we hope to improve this in the future, the NumPad plugin


### PR DESCRIPTION
It looks like we need to initialize Serial early for it to work with OSX, in addition to other tweaks we were making elsewhere. So lets do that first thing in `setup()`.
