### PR TITLE
Correct location of Makefile for library updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ After that, you'll want to update the Kaleidoscope libraries.
 
 ### MacOS
 ```sh
-cd $HOME/Documents/Arduino/hardware/keyboardio/avr
+cd $HOME/Documents/Arduino/hardware/keyboardio
 make update-submodules
 ```
 
 ### Linux
 
 ```sh
-cd $HOME/Arduino/hardware/keyboardio/avr
+cd $HOME/Arduino/hardware/keyboardio
 make update-submodules
 ```
 


### PR DESCRIPTION
The `Makefile` is one directory higher than was indicated in the README.