### PR TITLE
Fix turning LEDs off on suspend

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -355,9 +355,9 @@ static kaleidoscope::plugin::LEDSolidColor solidViolet(130, 0, 120);
 void toggleLedsOnSuspendResume(kaleidoscope::plugin::HostPowerManagement::Event event) {
   switch (event) {
   case kaleidoscope::plugin::HostPowerManagement::Suspend:
-    LEDControl.paused = true;
     LEDControl.set_all_leds_to({0, 0, 0});
     LEDControl.syncLeds();
+    LEDControl.paused = true;
     break;
   case kaleidoscope::plugin::HostPowerManagement::Resume:
     LEDControl.paused = false;


### PR DESCRIPTION
When suspending, we want to set all LEDs off & sync first, and only then pause LED operations. When the code was originally written, `LEDControl.syncLeds()` synced LEDs even when `LEDControl.paused` was set - it no longer does so, so we need to pause after we synced.

This addresses keyboardio/Kaleidoscope#516, at least partially.
