### PR TITLE
Update the EEPROMKeymap.setup() call to remove an obsolete argument

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -525,8 +525,9 @@ void setup() {
   // To make the keymap editable without flashing new firmware, we store
   // additional layers in EEPROM. For now, we reserve space for five layers. If
   // one wants to use these layers, just set the default layer to one in EEPROM,
-  // by using the `settings.defaultLayer` Focus command.
-  EEPROMKeymap.setup(5, EEPROMKeymap.Mode::EXTEND);
+  // by using the `settings.defaultLayer` Focus command, or by using the
+  // `keymap.onlyCustom` command to use EEPROM layers only.
+  EEPROMKeymap.setup(5);
 }
 
 /** loop is the second of the standard Arduino sketch functions.


### PR DESCRIPTION
EEPROM-Keymap was recently changed to work differently, and thus the mode argument became obsolete. This removes it from the call, and updates the comment above it to match current reality.
