### PR TITLE
Fallback settings for BOARD_HARDWARE_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,17 @@ KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR ?= keyboardio/build-tools/makefiles/
 # they reside outside of SKETCHBOOK_DIR, we fall back to assuming that 
 # the hardware directory can be determined in relation to the position of 
 # this Makefile.
-ifeq ("$(wildcard $(BOARD_HARDWARE_PATH)/keyboardio/avr/libraries/Kaleidoscope)","")
+ifeq ("$(wildcard $(BOARD_HARDWARE_PATH)/keyboardio/build-tools/makefiles/rules.mk)","")
    # Determine the path of this Makefile
    MKFILE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
    BOARD_HARDWARE_PATH = $(MKFILE_DIR)/../../../..
+endif
+
+ifeq ("$(wildcard $(BOARD_HARDWARE_PATH)/keyboardio/build-tools/makefiles/rules.mk)","")
+$(info ***************************************************************************)
+$(info Unable to autodetect a proper BOARD_HARDWARE_PATH. Please define it manually.)
+$(info ***************************************************************************)
+$(info )
 endif
 
 include $(BOARD_HARDWARE_PATH)/$(KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR)/rules.mk

--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,14 @@ endif
 BOARD_HARDWARE_PATH ?= $(SKETCHBOOK_DIR)/hardware
 KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR ?= keyboardio/build-tools/makefiles/
 
+# If Kaleidoscope's Arduino libraries cannot be found, e.g. because 
+# they reside outside of SKETCHBOOK_DIR, we fall back to assuming that 
+# the hardware directory can be determined in relation to the position of 
+# this Makefile.
+ifeq ("$(wildcard $(BOARD_HARDWARE_PATH)/keyboardio/avr/libraries/Kaleidoscope)","")
+   # Determine the path of this Makefile
+   MKFILE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+   BOARD_HARDWARE_PATH = $(MKFILE_DIR)/../../../..
+endif
+
 include $(BOARD_HARDWARE_PATH)/$(KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR)/rules.mk


### PR DESCRIPTION
This PR is a follow up of a [forum discussion](https://community.keyboard.io/t/how-to-work-on-several-unrelated-changes-plugins-issues-in-parallel/2594/12?u=noseglasses).

This commit allows the Makefile to check if the BOARD_HARDWARE_PATH
it tried to determine based on the system specific Arduino installation
is correct. This is done by checking for the Kaleidoscope library's existence.
If Kaleidoscope is not found, the Makefile falls back to determining
the hardware path relative to its own location. This even enables
building from any location where a *.ino file lives without
the requirement to checkout the kaleidoscope libraries into
Arduino installation's hardware path or to symlink them there.

The following now is possible

```
SOURCE_DIR=<place where the sources live>
cd $SOURCE_DIR
mkdir hardware
git clone --recursive <URL of the Kaleidoscope bundle> hardware/keyboardio
BUILD_DIR=<location where a *.ino file lives>
cd $BUILD_DIR
make -f $SOURCE_DIR/hardware/keyboardio/avr/libraries/Model01-Firmware/Makefile
```

for quick builds

```
SOURCE_DIR=<place where the sources live>
cd $SOURCE_DIR
mkdir hardware
git clone --recursive <URL of the Kaleidoscope bundle> hardware/keyboardio
cd hardware/keyboardio/avr/libraries/Model01-Firmware
make
```
The same could be applied to all makefiles.