### PR TITLE
remove unused enum

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -379,19 +379,6 @@ void hostPowerManagementEventHandler(kaleidoscope::plugin::HostPowerManagement::
   toggleLedsOnSuspendResume(event);
 }
 
-/** This 'enum' is a list of all the magic combos used by the Model 01's
- * firmware The names aren't particularly important. What is important is that
- * each is unique.
- *
- * These are the names of your magic combos. They will be used by the
- * `USE_MAGIC_COMBOS` call below.
- */
-enum {
-  // Toggle between Boot (6-key rollover; for BIOSes and early boot) and NKRO
-  // mode.
-  COMBO_TOGGLE_NKRO_MODE
-};
-
 /** A tiny wrapper, to be used by MagicCombo.
  * This simply toggles the keyboard protocol via USBQuirks, and wraps it within
  * a function with an unused argument, to match what MagicCombo expects.


### PR DESCRIPTION
This enum was a bit confusing :) 

> algernonToday at 4:21 PM
that enum can be safely removed. it used to be used for MagicCombos, but we reworked that plugin a while ago
looks like we forgot to remove the enum
feel free to send a PR that removes it :smiley: