### PR TITLE
Replaced Kaleidoscope-Model01-TestMode

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -61,7 +61,7 @@
 #include "Kaleidoscope-Colormap.h"
 
 // Support for Keyboardio's internal keyboard testing mode
-#include "Kaleidoscope-Model01-TestMode.h"
+#include "Kaleidoscope-HardwareTestMode.h"
 
 // Support for host power management (suspend & wakeup)
 #include "Kaleidoscope-HostPowerManagement.h"
@@ -423,7 +423,7 @@ KALEIDOSCOPE_INIT_PLUGINS(
 
   // The hardware test mode, which can be invoked by tapping Prog, LED and the
   // left Fn button at the same time.
-  TestMode,
+  HardwareTestMode,
 
   // LEDControl provides support for other LED modes
   LEDControl,


### PR DESCRIPTION
... with the more general Kaleidoscope-HardwareTestMode.
By this means, the stock firmware can be build
with the virtual hardware.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>