### PR TITLE
Include and initalize LEDPaletteTheme too

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -57,6 +57,9 @@
 // Support for an LED mode that prints the keys you press in letters 4px high
 #include "Kaleidoscope-LED-AlphaSquare.h"
 
+// Support for shared palettes for other plugins, like Colormap below
+#include "Kaleidoscope-LED-Palette-Theme.h"
+
 // Support for an LED mode that lets one configure per-layer color maps
 #include "Kaleidoscope-Colormap.h"
 
@@ -455,6 +458,10 @@ KALEIDOSCOPE_INIT_PLUGINS(
 
   // The stalker effect lights up the keys you've pressed recently
   StalkerEffect,
+
+  // The LED Palette Theme plugin provides a shared palette for other plugins,
+  // like Colormap below
+  LEDPaletteTheme,
 
   // The Colormap effect makes it possible to set up per-layer colormaps
   ColormapEffect,


### PR DESCRIPTION
Without the `LEDPaletteTheme` plugin, `Colormap` doesn't work either, since the palette is not initialized. Lets include and initialize the palette plugin too.

Fixes #86.
