### PR TITLE
Update to use new apis

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -310,7 +310,7 @@ static void anyKeyMacro(uint8_t keyState) {
   }
 
   if (keyIsPressed(keyState))
-    kaleidoscope::hid::pressKey(lastKey, toggledOn);
+    Kaleidoscope.hid().keyboard().pressKey(lastKey, toggledOn);
 }
 
 

--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -361,13 +361,10 @@ static kaleidoscope::plugin::LEDSolidColor solidViolet(130, 0, 120);
 void toggleLedsOnSuspendResume(kaleidoscope::plugin::HostPowerManagement::Event event) {
   switch (event) {
   case kaleidoscope::plugin::HostPowerManagement::Suspend:
-    LEDControl.set_all_leds_to({0, 0, 0});
-    LEDControl.syncLeds();
-    LEDControl.paused = true;
+    LEDControl.disable();
     break;
   case kaleidoscope::plugin::HostPowerManagement::Resume:
-    LEDControl.paused = false;
-    LEDControl.refreshAll();
+    LEDControl.enable();
     break;
   case kaleidoscope::plugin::HostPowerManagement::Sleep:
     break;


### PR DESCRIPTION
- Use `Kaleidoscope.hid()` instead of the old `kaleidoscope::hid` facade
- Use `LEDControl.enable()`/`LEDControl.disable()` instead of `LEDControl.paused`

The former is a build fix, because the HID facade is not included by default anymore. The latter just silences warnings.