### PR TITLE
Use Keypad numbers for numpad

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -255,10 +255,10 @@ KEYMAPS(
    ___, ___, ___, ___,
    ___,
 
-   M(MACRO_VERSION_INFO),  ___, Key_7, Key_8,      Key_9,              Key_KeypadSubtract, ___,
-   ___,                    ___, Key_4, Key_5,      Key_6,              Key_KeypadAdd,      ___,
-                           ___, Key_1, Key_2,      Key_3,              Key_Equals,         ___,
-   ___,                    ___, Key_0, Key_Period, Key_KeypadMultiply, Key_KeypadDivide,   Key_Enter,
+   M(MACRO_VERSION_INFO),  ___, Key_Keypad7, Key_Keypad8,   Key_Keypad9,        Key_KeypadSubtract, ___,
+   ___,                    ___, Key_Keypad4, Key_Keypad5,   Key_Keypad6,        Key_KeypadAdd,      ___,
+                           ___, Key_Keypad1, Key_Keypad2,   Key_Keypad3,        Key_KeypadEquals,   ___,
+   ___,                    ___, Key_Keypad0, Key_KeypadDot, Key_KeypadMultiply, Key_KeypadDivide,   Key_KeypadEnter,
    ___, ___, ___, ___,
    ___),
 


### PR DESCRIPTION
I use my keyboard together with a Programmer Dvorak layout at the OS level. This layout changes the numbers in the top row to be activated when shift is pressed, without shift it does braces and arithmetic operators.
The numpad numbers are supposed to work without pressing shift though. This fixes that in the default layout by using the Keypad variants of all keys for the numpad keymap.