### PR TITLE
Add build date/time to default version info

### DIFF
--- a/Model01-Firmware.ino
+++ b/Model01-Firmware.ino
@@ -3,7 +3,7 @@
 // See "LICENSE" for license details
 
 #ifndef BUILD_INFORMATION
-#define BUILD_INFORMATION "locally built"
+#define BUILD_INFORMATION "locally built on " __DATE__ " at " __TIME__
 #endif
 
 


### PR DESCRIPTION
Example output from the version info macro:

```
Keyboardio Model 01 - Kaleidoscope locally built on Sep  3 2021 at 09:40:27
```